### PR TITLE
DWDS Custom App: Adds "About URL" to info.json

### DIFF
--- a/DWDS/info.json
+++ b/DWDS/info.json
@@ -2,5 +2,6 @@
     "app_name": "DWDS",
     "zim_url": "https://www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2023-11-20.zim",
     "zim_auth": "DWDS_HTTP_BASIC_ACCESS_AUTHENTICATION",
-    "enforced_lang": "de"
+    "enforced_lang": "de",
+    "about_app_url": "https://www.dwds.de/a/"
 }


### PR DESCRIPTION
This PR aligns the setting of "About URL"  in `info.json` with the Android version.

Please consider migrating the configuration setting `CUSTOM_ABOUT_WEBSITE` from `DWDS.xcconfig` to `about_app_url` in `info.json`, thereby also adjusting the URL.

Thanks!