### PR TITLE
Downgrade semantic version

### DIFF
--- a/src/info_parser.py
+++ b/src/info_parser.py
@@ -56,7 +56,8 @@ class InfoParser:
         dict = {
             "templates": ["ApplicationTemplate"],
             "settings": {"base": {
-                "MARKETING_VERSION": self.version.semantic,
+                # TODO: change to .semantic, once builds are OK
+                "MARKETING_VERSION": self.version.semantic_downgraded, 
                 "PRODUCT_BUNDLE_IDENTIFIER": f"org.kiwix.custom.{self.brand_name}",
                 "INFOPLIST_FILE": f"custom/{self._info_plist_path()}",
                 "INFOPLIST_KEY_CFBundleDisplayName": self._app_name(),

--- a/src/tag_validator.py
+++ b/src/tag_validator.py
@@ -38,7 +38,7 @@ def _is_valid(tag):
         if parser.version != version:
             _exit_with_error(f"Invalid date in tag: {tag}, does not match year.month of ZIM file in {brand.info_file}, it should be: {parser.version.semantic}")
             
-        print(f"{brand.name} {version.semantic_downgraded}")
+        print(f"{brand.name} {version.build_number}")
         
     else:
         _exit_with_error(f"Invalid tag: {tag}")


### PR DESCRIPTION
Downgrade semantic version for testing the builds:
making sure we can distinguish between automated new builds and former manual builds.