### PR TITLE
Remove support url

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ These key / values can be, but do not need to be included in the `info.json` fil
 
 - `bundle_id` - (optional) It should match to the bundle id set on the Apple Developer website for this app. If it's not set it will default to: "org.kiwix.custom.{brand_name}", where the brand name is the name of the folder, eg: "org.kiwix.custom.dwds".
 
-- `support_url` - (optional) The _"Support \\(app_name)"_ item in the sidebar by default links to: "https://kiwix.org/get-involved/". This link target can be changed by setting `support_url`. It has to be a vaild URL. If setting it to an invalid URL, eg. empty value: `"support_url": ""`, the _"Support \\(app_name)"_ item will be hidden in the app.
-
 - `zim_auth` - (optional) this is needed if standard http authentication is required to download the ZIM file. This should be set to **an environment variable name**, which will be resolved during build time. Make sure that the environment variable itself is set up properly before running the build process. **Do not place any credentials directly here, it's not safe, and won't work.**
 
 ## XCAssets file

--- a/src/info_parser.py
+++ b/src/info_parser.py
@@ -20,8 +20,7 @@ JSON_TO_PLIST_MAPPING = {
     "about_text": "CUSTOM_ABOUT_TEXT",
     "settings_default_external_link_to": "SETTINGS_DEFAULT_EXTERNAL_LINK_TO",
     "settings_show_search_snippet": "SETTINGS_SHOW_SEARCH_SNIPPET",
-    "settings_show_external_link_option": "SETTINGS_SHOW_EXTERNAL_LINK_OPTION",
-    "support_url": "SUPPORT_URL"
+    "settings_show_external_link_option": "SETTINGS_SHOW_EXTERNAL_LINK_OPTION"
 }
 
 


### PR DESCRIPTION
Removing the SUPPORT_URL option from custom apps, as it's no longer implemented on kiwix-apple.

Note: It wasn't customised by DWDS.