### PR TITLE
Externalise development_team

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ targets:
     settings:
       base:
         DEVELOPMENT_LANGUAGE: de
+        DEVELOPMENT_TEAM: L7HWM3SP3L,
         INFOPLIST_FILE: custom/dwds/dwds.plist
         INFOPLIST_KEY_CFBundleDisplayName: DWDS
         INFOPLIST_KEY_UILaunchStoryboardName: SplashScreen.storyboard

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ existing one if you need to create a new custom app.
 - `about_text` - this is a custom text that is placed in the "About section" describing what the application is about. It is not supporting html tags, but new lines can be added with '\n'.
 - `app_name` - Name of the app, as it will appear on device, and in App Store
 - `app_store_id` - this should to be taken from the developer.apple.com, where the application release is prepared. Note you can use the app_store_id even if the app is not yet released. The id is used within the app in the "Rate the app" section, so users can be redirected to a specific app in the App Store, to rate it.
+- `development_team` - this is the development team id used for the build, it can be found in the relevant Apple Development Account (for apps under the Kiwix organisation it will be the same value: L7HWM3SP3L)
 - `enforced_lang` - ISO 639-1 language code (eg: en, de, he) if it is set, it will include only this language in the final app, meaning no other languages can be selected (on iOS) for the application UI. See the current list of supported languages [already translated in the main repo](https://github.com/kiwix/kiwix-apple/tree/main/Support). When using this option, make sure that [the translation coverage](https://translatewiki.net/wiki/Special:MessageGroupStats/kiwix-apple?group=kiwix-apple&messages=&suppressempty=1&x=D) is 100% for the enforced language.
 
     If enforced_lang is not added to the info.json file, all languages will be supported by the app, just like in Kiwix.

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -3,6 +3,7 @@
     "about_text": "Für Schreibende, Lernende, Lehrende und Sprachinteressierte: Das Digitale Wörterbuch der deutschen Sprache (DWDS) ist das große Bedeutungswörterbuch des Deutschen der Gegenwart. Es bietet umfassende und wissenschaftlich verlässliche lexikalische Informationen, kostenlos und werbefrei.",
     "app_name": "DWDS",
     "app_store_id": "id6473090365",
+    "development_team": "L7HWM3SP3L",
     "enforced_lang": "de",
     "settings_default_external_link_to": "alwaysLoad",
     "settings_show_external_link_option": false,

--- a/src/info_parser.py
+++ b/src/info_parser.py
@@ -13,6 +13,7 @@ JSON_KEY_AUTH = "zim_auth"
 JSON_BUNDLE_ID = "bundle_id"
 JSON_KEY_APP_NAME = "app_name"
 JSON_KEY_ENFORCED_LANGUAGE = "enforced_lang"
+JSON_KEY_DEVELOPMENT_TEAM = "development_team"
 CUSTOM_ZIM_FILE_KEY = "CUSTOM_ZIM_FILE"
 JSON_TO_PLIST_MAPPING = {
     "app_store_id": "APP_STORE_ID",
@@ -63,13 +64,14 @@ class InfoParser:
                 "INFOPLIST_FILE": f"custom/{self._info_plist_path()}",
                 "INFOPLIST_KEY_CFBundleDisplayName": self._app_name(),
                 "INFOPLIST_KEY_UILaunchStoryboardName": "SplashScreen.storyboard",
-                "DEVELOPMENT_LANGUAGE": self._dev_language()
+                "DEVELOPMENT_LANGUAGE": self._dev_language(),
                 # without specifying DEVELOPMENT_LANGUAGE,
                 # the default value of it: English will be added to the list of
                 # selectable languages in iOS Settings,
                 # even if the en.lproj is excluded from the sources.
                 # If DEVELOPMENT_LANGUAGE is not added, enforcing a single language is not effective,
                 # therefore it's better to set it to the enforced language value if there's such.
+                "DEVELOPMENT_TEAM": self._development_team()
             }
             },
             "sources": [
@@ -119,6 +121,9 @@ class InfoParser:
 
     def _app_name(self):
         return self.data[JSON_KEY_APP_NAME]
+    
+    def _development_team(self):
+        return self.data[JSON_KEY_DEVELOPMENT_TEAM]
 
     def _dev_language(self):
         enforced = self._enforced_language()

--- a/testapp/info.json
+++ b/testapp/info.json
@@ -3,6 +3,7 @@
     "about_text": "CI Test Application",
     "app_name": "TestApp",
     "app_store_id": "id1281693200",
+    "development_team": "L7HWM3SP3L",
     "enforced_lang": "en",
     "settings_default_external_link_to": "alwaysLoad",
     "settings_show_external_link_option": true,

--- a/wikimed/info.json
+++ b/wikimed/info.json
@@ -4,6 +4,7 @@
     "app_name": "WikiMed",
     "app_store_id": "id1281693200",
     "bundle_id": "org.kiwix.wikimed",
+    "development_team": "L7HWM3SP3L",
     "enforced_lang": "en",
     "settings_default_external_link_to": "alwaysLoad",
     "settings_show_external_link_option": true,


### PR DESCRIPTION
In order to achieve dealing with another Apple Dev account, as one of the first steps, we need to externalise the development team per project.

## Solution:

The appropriate key has been added to the json files (currently the same value we have for Kiwix account, although I have tested with a different one for DWDS, and it's working as expected).
The development team id is then put into the custom_apps.yaml project, which updates the Xcode project as expected.