### PR TITLE
Fix CI: Add development team to tests

### DIFF
--- a/tests/test.json
+++ b/tests/test.json
@@ -4,6 +4,7 @@
     "app_name": "DWDS",
     "app_store_id": "id6473090365",
     "enforced_lang": "de",
+    "development_team": "L7HWM3SP3L",
     "settings_default_external_link_to": "alwaysLoad",
     "settings_show_search_snippet": false,
     "settings_show_external_link_option": false,


### PR DESCRIPTION
Missing piece from the last PR, the development_team key was missing from the test json file.