### PR TITLE
Add bundle id for DWDS, remove unused var on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 env:
   KEYCHAIN: /Users/runner/build.keychain-db
   KEYCHAIN_PASSWORD: mysecretpassword
-  KEYCHAIN_PROFILE: build-profile
   SSH_KEY: /tmp/id_rsa
   APPLE_STORE_AUTH_KEY_PATH: /tmp/authkey.p8
 
@@ -151,5 +150,4 @@ jobs:
           DEPLOYMENT_SIGNING_CERTIFICATE_P12_PASSWORD: ${{ env.SIGNING_CERTIFICATE_P12_PASSWORD }}
           KEYCHAIN: ${{ env.KEYCHAIN }}
           KEYCHAIN_PASSWORD: ${{ env.KEYCHAIN_PASSWORD }}
-          KEYCHAIN_PROFILE: ${{ env.KEYCHAIN_PROFILE }}
           EXTRA_XCODEBUILD: ${{ env.EXTRA_XCODEBUILD }}

--- a/dwds/info.json
+++ b/dwds/info.json
@@ -3,6 +3,7 @@
     "about_text": "Für Schreibende, Lernende, Lehrende und Sprachinteressierte: Das Digitale Wörterbuch der deutschen Sprache (DWDS) ist das große Bedeutungswörterbuch des Deutschen der Gegenwart. Es bietet umfassende und wissenschaftlich verlässliche lexikalische Informationen, kostenlos und werbefrei.",
     "app_name": "DWDS",
     "app_store_id": "id6741328425",
+    "bundle_id": "de.dwds.app",
     "development_team": "Q2QUKNPZG9",
     "enforced_lang": "de",
     "settings_default_external_link_to": "alwaysLoad",


### PR DESCRIPTION
There's still one more thing missing for the DWDS release, the appropriate bundle id, that has been set up on AppStoreConnect.