### PR TITLE
Use kiwix latest release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Find latest stable release of kiwix-apple, unless triggering tag indicates develop branch
         if: ${{ !contains(github.ref, '_dev') }}
         id: kiwix_latest_release
-        uses: joutvhu/get-release@v1.0.3
+        uses: joutvhu/get-release@9a8271732adc3299a22f8ad09b0a67eb3aa836ac #v1.0.3
         with:
           latest: true
           prerelease: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Find latest stable release of kiwix-apple, unless triggering tag indicates develop branch
         if: ${{ !contains(github.ref, '_dev') }}
         id: kiwix_latest_release
-        uses: joutvhu/get-release@v1
+        uses: joutvhu/get-release@v1.0.3
         with:
           latest: true
           prerelease: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,11 +41,22 @@ jobs:
           python src/tag_validator.py ${{ steps.vars.outputs.tag }}
           cd ..
 
+      - name: Find latest stable release of kiwix-apple, unless triggering tag indicates develop branch
+        if: ${{ !contains(github.ref, '_dev') }}
+        id: kiwix_latest_release
+        uses: joutvhu/get-release@v1
+        with:
+          latest: true
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check-out kiwix/kiwix-apple
         uses: actions/checkout@v4
         with:
           repository: kiwix/kiwix-apple
           path: apple
+          ref: ${{ !contains(github.ref, '_dev') && steps.kiwix_latest_release.outputs.tag_name || '' }}
 
       - name: Install Python dependencies for custom project generation
         run: python -m pip install pyyaml

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Where the:
 
 Note: Both iOS and macOS applications are created from the same source code and are versioned and released together.
 
+Currently the [latest stable release of the Kiwix Apple repository](https://github.com/kiwix/kiwix-apple/releases) is checked out to form a custom app release.
+If needed, the development branch of Kiwix can also be used, by adding "_dev" to the release tag, it can be added somewhere at the end of the tag, as all other tag validations (described above) still need to be met, eg: "dwds_2023.12.10_dev_01".
+
 # Release from an external Apple Account (non Kiwix)
 In order to use a different Apple Account for your app, further setup is required.
 


### PR DESCRIPTION
Fixes: #68 

By default we can now use the latest Kiwix release.
As in our current case with DWDS (we are waiting for TranslateWiki updates), it is possible to use the develop branch as well, by including "_dev" in the release tag (see updated README).