### PR TITLE
Update to macOS 14

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
           - platform: macOS
           - platform: iOS
             xcode_extra: -sdk iphoneos
-    runs-on: macos-13
+    runs-on: macos-14
     environment: ${{ contains(github.ref, 'dwds') && 'dwds' || 'internal' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - platform: macOS
           - platform: iOS
             xcode_extra: -sdk iphoneos
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
In parallel to the [kiwix-apple update](https://github.com/kiwix/kiwix-apple/pull/1120/files#diff-ad45ef8bdbd0e61bfa946c79069c7edef52b45951251a30515c18e195b19091b), we need to update these CI/CD processes as well.