### PR TITLE
Fix CI/CD after bundle changes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,6 +66,10 @@ jobs:
           cd apple
           cat Brewfile | grep -v -e pre-commit > Brewfile_CI
           brew bundle --force --file Brewfile_CI
+          cp Support/CoreKiwix.modulemap CoreKiwix.xcframework/ios-arm64/Headers/module.modulemap
+          cp Support/CoreKiwix.modulemap CoreKiwix.xcframework/ios-arm64_x86_64-simulator/Headers/module.modulemap
+          cp Support/CoreKiwix.modulemap CoreKiwix.xcframework/macos-arm64_x86_64/Headers/module.modulemap
+          python localizations.py generate
           cd ..
 
       - name: Generate project based on tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
         run: | # remove pre-commit, it's not needed for CI
           cat Brewfile | grep -v -e pre-commit > Brewfile_CI
           brew bundle --force --file Brewfile_CI
+          cp Support/CoreKiwix.modulemap CoreKiwix.xcframework/ios-arm64/Headers/module.modulemap
+          cp Support/CoreKiwix.modulemap CoreKiwix.xcframework/ios-arm64_x86_64-simulator/Headers/module.modulemap
+          cp Support/CoreKiwix.modulemap CoreKiwix.xcframework/macos-arm64_x86_64/Headers/module.modulemap
+          python localizations.py generate
 
       - name: Generate project based on tag
         env:


### PR DESCRIPTION
After some bundle changes, the [at_exit hook](https://github.com/kiwix/kiwix-apple/blob/1b98031b3227265d65b2563a1db4dab41834e97c/Brewfile#L5) stoped working,
as a workaround we need to launch those commands in the CI/CD sleps.
