### PR TITLE
Remove audio (Background mode) from WikiMed

### DIFF
--- a/wikimed/info.json
+++ b/wikimed/info.json
@@ -9,7 +9,7 @@
     "settings_default_external_link_to": "alwaysLoad",
     "settings_show_external_link_option": true,
     "settings_show_search_snippet": false,
-    "uses_audio": true,
+    "uses_audio": false,
     "zim_recipe": "https://farm.openzim.org/recipes/mdwiki_app",
     "zim_url": "https://mirror.download.kiwix.org/zim/.hidden/custom_apps/mdwiki_en_all-app_maxi_2025-08.zim"
 }


### PR DESCRIPTION
From the latest App Store review:

> If the app has a feature that requires persistent audio, reply to this message and let us know how to locate this feature. If the app does not have a feature that requires persistent audio, it would be appropriate to remove the "audio" setting from the UIBackgroundModes key.

Removing it for WikiMed