### PR TITLE
Fix finding the latest kiwix-apple release tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,6 +46,7 @@ jobs:
         id: kiwix_latest_release
         uses: joutvhu/get-release@9a8271732adc3299a22f8ad09b0a67eb3aa836ac #v1.0.3
         with:
+          repo: kiwix-apple
           latest: true
           prerelease: false
         env:


### PR DESCRIPTION
Fixes: #115 

Tested here:
https://github.com/kiwix/kiwix-apple-custom/actions/runs/19207491007/job/54904796381