### PR TITLE
Update DWDS Custom App ZIM to v2025-11-18

### DIFF
--- a/dwds/info.json
+++ b/dwds/info.json
@@ -12,5 +12,5 @@
     "show_search_suggestions_spellchecked": true,
     "uses_audio": false,
     "zim_auth": "HTTP_BASIC_ACCESS_AUTHENTICATION",
-    "zim_url": "https://www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2025-02-11.zim"
+    "zim_url": "https://www.dwds.de/kiwix/f/dwds_de_dictionary_nopic_2025-11-18.zim"
 }


### PR DESCRIPTION
This ZIM file was built using libzim 9.4.0, and includes:

* an update for the DWDS dictionary
* a native dark mode using Dark Reader as bundled JS dependency